### PR TITLE
Improve validation of response status and content.

### DIFF
--- a/src/jsonapi-source.js
+++ b/src/jsonapi-source.js
@@ -9,6 +9,7 @@ import JSONAPISerializer from './jsonapi-serializer';
 import { encodeQueryParams } from './lib/query-params';
 import { getQueryRequests, QueryRequestProcessors } from './lib/queries';
 import { getTransformRequests, TransformRequestProcessors } from './lib/transform-requests';
+import { InvalidServerResponse } from './lib/exceptions';
 
 if (typeof self.fetch !== 'undefined' && Orbit.fetch === undefined) {
   Orbit.fetch = self.fetch;
@@ -137,7 +138,13 @@ export default class JSONAPISource extends Source {
   }
 
   handleFetchResponse(response) {
-    if (response.status >= 200 && response.status < 300) {
+    if (response.status === 201) {
+      if (this.responseHasContent(response)) {
+        return response.json();
+      } else {
+        throw new InvalidServerResponse(`Server responses with a ${response.status} status should return content with a Content-Type that includes 'application/vnd.api+json'.`);
+      }
+    } else if (response.status >= 200 && response.status < 300) {
       if (this.responseHasContent(response)) {
         return response.json();
       } else {

--- a/src/jsonapi-source.js
+++ b/src/jsonapi-source.js
@@ -170,7 +170,8 @@ export default class JSONAPISource extends Source {
   }
 
   responseHasContent(response) {
-    return response.headers.get('Content-Type') === 'application/vnd.api+json';
+    let contentType = response.headers.get('Content-Type');
+    return contentType && contentType.indexOf('application/vnd.api+json') > -1;
   }
 
   resourceNamespace(/* type */) {

--- a/src/lib/exceptions.js
+++ b/src/lib/exceptions.js
@@ -1,0 +1,8 @@
+import { Exception } from 'orbit/lib/exceptions';
+
+export class InvalidServerResponse extends Exception {
+  constructor(message) {
+    super(message);
+    this.name = 'OrbitJSONAPI.InvalidServerResponse';
+  }
+}

--- a/test/tests/support/jsonapi.js
+++ b/test/tests/support/jsonapi.js
@@ -12,15 +12,11 @@ export function jsonapiResponse(_options, _body) {
 
   options.statusText = options.statusText || statusText(options.status);
   options.headers = options.headers || {};
-
-  let response;
-
   if (body) {
     options.headers['Content-Type'] = 'application/vnd.api+json';
-    response = new self.Response(body, options);
-  } else {
-    response = new self.Response(options);
   }
+
+  let response = new self.Response(body, options);
 
   // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));
 

--- a/test/tests/unit/jsonapi-serializer-test.js
+++ b/test/tests/unit/jsonapi-serializer-test.js
@@ -9,7 +9,7 @@ let keyMap;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('OC - JSONAPISerializer', {
+module('JSONAPISerializer', {
   beforeEach() {
     keyMap = new KeyMap();
   },

--- a/test/tests/unit/jsonapi-source-test.js
+++ b/test/tests/unit/jsonapi-source-test.js
@@ -130,6 +130,17 @@ test('#defaultFetchHeaders - include JSONAPI Accept header by default', function
   assert.deepEqual(source.defaultFetchHeaders, { Accept: 'application/vnd.api+json' }, 'Default headers should include JSONAPI Accept header');
 });
 
+test('#responseHasContent - returns true if JSONAPI media type appears anywhere in Content-Type header', function(assert) {
+  let response = new self.Response('{ data: null }', { headers: { 'Content-Type': 'application/vnd.api+json' } });
+  assert.equal(source.responseHasContent(response), true, 'Accepts content that is _only_ the JSONAPI media type.');
+
+  response = new self.Response('{ data: null }', { headers: { 'Content-Type': 'application/json,application/vnd.api+json; charset=utf-8' } });
+  assert.equal(source.responseHasContent(response), true, 'Position of JSONAPI media type is not important.');
+
+  response = new self.Response('{ data: null }', { headers: { 'Content-Type': 'application/json' } });
+  assert.equal(source.responseHasContent(response), false, 'Plain json can not be parsed by default.');
+});
+
 test('#push - can add records', function(assert) {
   assert.expect(6);
 

--- a/test/tests/unit/jsonapi-source-test.js
+++ b/test/tests/unit/jsonapi-source-test.js
@@ -3,7 +3,6 @@ import Source from 'orbit/source';
 import { uuid } from 'orbit/lib/uuid';
 import Schema from 'orbit/schema';
 import KeyMap from 'orbit/key-map';
-import JSONAPISource from 'orbit-jsonapi/jsonapi-source';
 import Transform from 'orbit/transform';
 import qb from 'orbit/query/builder';
 import { TransformNotAllowed } from 'orbit/lib/exceptions';
@@ -18,13 +17,14 @@ import {
   replaceHasMany,
   replaceHasOne
 } from 'orbit/transform/operators';
+import JSONAPISource from 'orbit-jsonapi/jsonapi-source';
 import { jsonapiResponse } from 'tests/test-helper';
 
 let fetchStub, keyMap, source;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('OC - JSONAPISource - with a secondary key', {
+module('JSONAPISource - with a secondary key', {
   setup() {
     fetchStub = sinon.stub(Orbit, 'fetch');
 
@@ -675,7 +675,7 @@ test('#pull - relatedRecords', function(assert) {
   });
 });
 
-module('OC - JSONAPISource - with no secondary keys', {
+module('JSONAPISource - with no secondary keys', {
   setup() {
     fetchStub = sinon.stub(Orbit, 'fetch');
 


### PR DESCRIPTION
- `responseHasContent` is now more forgiving and returns true if the JSONAPI media type appears anywhere in a response’s `Content-Type` header.
- When a server responds with a 201 but does not include content, throw a new `InvalidServerResponseException`.

/cc @mitchlloyd

[Fixes #3]
